### PR TITLE
Use a templates file to specify version ranges.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 binrc
 vendor
 releases
+statik

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 all: test build ## Run the tests and build the binary.
 
 build: ## Build the binary.
+	@rm -rf statik
+	@go generate
 	@go build -ldflags "-X github.com/netlify/binrc/cmd.Version=`git rev-parse HEAD`"
 
 deps: ## Install dependencies.

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -108,7 +108,9 @@ func (c *Cache) newProject(name, versionString string) (*Project, error) {
 	if !strings.HasPrefix(versionString, "v") {
 		versionString = "v" + versionString
 	}
-	cleanVersion, err := version.NewVersion(strings.TrimLeft(versionString, "v"))
+
+	cleanVersionString := strings.TrimLeft(versionString, "v")
+	cleanVersion, err := version.NewVersion(cleanVersionString)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid version %s", versionString)
 	}
@@ -139,7 +141,7 @@ func (c *Cache) newProject(name, versionString string) (*Project, error) {
 		Version:      versionString,
 		Owner:        nwo[0],
 		Name:         nwo[1],
-		cleanVersion: cleanVersion.String(),
+		cleanVersion: cleanVersionString,
 		template:     t,
 	}, nil
 }

--- a/cmd/install_cmd.go
+++ b/cmd/install_cmd.go
@@ -28,7 +28,11 @@ func execInstallCmd(cmd *cobra.Command, args []string) {
 
 		sp = path.Clean(path.Join(h, sp))
 	}
-	c := cache.New(sp)
+	c, err := cache.New(sp)
+	if err != nil {
+		displayError(err)
+		return
+	}
 
 	var version string
 	if len(args) > 1 {

--- a/lock.json
+++ b/lock.json
@@ -1,6 +1,22 @@
 {
-    "memo": "c3e7bfd5ea96b0b7eeb7b1e93aa052d4af4425808e9e12f0aa1fe6b0adbdb086",
+    "memo": "1f0ab0b3dfffae2040e9d15511408d8420bffad799aea6326c4ef3490cc7429a",
     "projects": [
+        {
+            "name": "github.com/BurntSushi/toml",
+            "version": "v0.3.0",
+            "revision": "b26d9c308763d68093482582cea63d69be07a0f0",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/hashicorp/go-version",
+            "branch": "master",
+            "revision": "03c5bf6be031b6dd45afec16b1cf94fc8938bc77",
+            "packages": [
+                "."
+            ]
+        },
         {
             "name": "github.com/inconshreveable/mousetrap",
             "branch": "master",
@@ -10,16 +26,41 @@
             ]
         },
         {
+            "name": "github.com/mitchellh/go-homedir",
+            "branch": "master",
+            "revision": "b8bc1bf767474819792c23f32d8286a45736f1c6",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/pkg/errors",
+            "version": "v0.8.0",
+            "revision": "3866ebc348c54054262feae422da428fe6cf147d",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/rakyll/statik",
+            "version": "v0.1.0",
+            "revision": "274df120e9065bdd08eb1120e0375e3dc1ae8465",
+            "packages": [
+                "fs"
+            ]
+        },
+        {
             "name": "github.com/spf13/cobra",
             "branch": "master",
-            "revision": "4c05eb1145f16d0e6bb4a3e1b6d769f4713cb41f",
+            "revision": "6ed17b5128e8932c9ecd4c3970e8ea5e60a418ac",
             "packages": [
                 "."
             ]
         },
         {
             "name": "github.com/spf13/pflag",
-            "revision": "7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7",
+            "branch": "master",
+            "revision": "2300d0f8576fe575f71aaa5b9bbe4e1b0dc2eb51",
             "packages": [
                 "."
             ]

--- a/main.go
+++ b/main.go
@@ -1,3 +1,5 @@
+//go:generate statik -src=./templates
+
 package main
 
 import (

--- a/templates/templates.toml
+++ b/templates/templates.toml
@@ -1,0 +1,4 @@
+hugo = [
+  { range = ">=0.19, <0.20.3", tarball = "%s_v%s_Linux-64bit.tar.gz", bin = "%s_%s_linux_amd64/%s_%s_linux_amd64" },
+  { range = ">=0.20.3",        tarball = "%s_%s_Linux-64bit.tar.gz",  bin = "hugo" }
+]

--- a/templates/templates.toml
+++ b/templates/templates.toml
@@ -1,4 +1,5 @@
 hugo = [
-  { range = ">=0.19, <0.20.3", tarball = "%s_v%s_Linux-64bit.tar.gz", bin = "%s_%s_linux_amd64/%s_%s_linux_amd64" },
-  { range = ">=0.20.3",        tarball = "%s_%s_Linux-64bit.tar.gz",  bin = "hugo" }
+  { range = ">=0.19, <0.20.3", tarball = "%s_%s_Linux-64bit.tar.gz", bin = "%s_%s_linux_amd64/%s_%s_linux_amd64" },
+  { range = "0.20.3",          tarball = "%s_v%s_Linux-64bit.tar.gz",  bin = "hugo" },
+  { range = ">0.20.3",         tarball = "%s_%s_Linux-64bit.tar.gz",  bin = "hugo" }
 ]


### PR DESCRIPTION
This change will allow us to specify path templates
for different versions of a package.

The template.toml file is embedded in the binary on
compile time, so we don't have to download it, however, you
can set your own template path if you need to.

There is an additional optimization that we can do later to
use the text/template package to create the template strings,
but this should work for the Hugo's random release name changes.

Signed-off-by: David Calavera <david.calavera@gmail.com>