### PR TITLE
Increase available backlog range of hugo versions

### DIFF
--- a/templates/templates.toml
+++ b/templates/templates.toml
@@ -1,5 +1,6 @@
 hugo = [
-  { range = ">=0.19, <0.20.3", tarball = "%s_%s_Linux-64bit.tar.gz", bin = "%s_%s_linux_amd64/%s_%s_linux_amd64" },
+  { range = "0.16",            tarball = "%s_%s_linux-64bit.tgz", bin = "hugo" },
+  { range = ">=0.17, <0.20.3", tarball = "%s_%s_Linux-64bit.tar.gz", bin = "%s_%s_linux_amd64/%s_%s_linux_amd64" },
   { range = "0.20.3",          tarball = "%s_v%s_Linux-64bit.tar.gz",  bin = "hugo" },
   { range = ">0.20.3",         tarball = "%s_%s_Linux-64bit.tar.gz",  bin = "hugo" }
 ]


### PR DESCRIPTION
Allow hugo installations back to 0.16



