### PR TITLE
Support Hugo new Extended version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ please read the [code of conduct](CODE_OF_CONDUCT.md).
 
 ## Setup
 
-> Install Go and Dep https://github.com/golang/deb
+> Install Go and Dep https://github.com/golang/dep
 
 ```sh
 $ git clone https://github.com/netlify/binrc

--- a/templates/templates.toml
+++ b/templates/templates.toml
@@ -3,7 +3,8 @@ hugo = [
   { range = "0.16",            tarball = "%s_%s_linux-64bit.tgz", bin = "hugo" },
   { range = ">=0.17, <0.20.3", tarball = "%s_%s_Linux-64bit.tar.gz", bin = "%s_%s_linux_amd64/%s_%s_linux_amd64" },
   { range = "0.20.3",          tarball = "%s_v%s_Linux-64bit.tar.gz",  bin = "hugo" },
-  { range = ">0.20.3",         tarball = "%s_%s_Linux-64bit.tar.gz",  bin = "hugo" }
+  { range = ">0.20.3, <0.43",  tarball = "%s_%s_Linux-64bit.tar.gz",  bin = "hugo" },
+  { range = ">=0.43",          tarball = "%s_extended_%s_Linux-64bit.tar.gz",  bin = "hugo" },
 ]
 
 gutenberg = [


### PR DESCRIPTION
**- Summary**

Changes `templates.toml` to support the new extended version of Hugo v0.43 as default. References at #16.

**- Test plan**

**- Description for the changelog**

Add extended version for Hugo >=0.43
