### PR TITLE
Add zola

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build: ## Build the binary.
 	@go build -ldflags "-X github.com/netlify/binrc/cmd.Version=`git rev-parse HEAD`"
 
 deps: ## Install dependencies.
-	@go get -u github.com/rakyll/statik
+	@go get -u github.com/Keats/statik
 	@go get -u github.com/golang/lint/golint
 	@go get -u github.com/golang/dep/cmd/dep && dep ensure
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build: ## Build the binary.
 	@go build -ldflags "-X github.com/netlify/binrc/cmd.Version=`git rev-parse HEAD`"
 
 deps: ## Install dependencies.
-	@go get -u github.com/Keats/statik
+	@go get -u github.com/rakyll/statik
 	@go get -u github.com/golang/lint/golint
 	@go get -u github.com/golang/dep/cmd/dep && dep ensure
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -34,6 +34,7 @@ const (
 var aliases = map[string]string{
 	"hugo": "spf13/hugo",
 	"gutenberg": "keats/gutenberg",
+	"zola": "getzola/zola",
 }
 
 type template struct {

--- a/templates/templates.toml
+++ b/templates/templates.toml
@@ -12,5 +12,5 @@ gutenberg = [
 ]
 
 zola = [
-  { range = ">=0.4.3", tarball = "%s-v%s-x86_64-unknown-linux-gnu.tar.gz", bin = "zola" }
+  { range = ">=0.5.0", tarball = "%s-v%s-x86_64-unknown-linux-gnu.tar.gz", bin = "zola" }
 ]

--- a/templates/templates.toml
+++ b/templates/templates.toml
@@ -8,5 +8,9 @@ hugo = [
 ]
 
 gutenberg = [
-  { range = ">0.0.5", tarball = "%s-v%s-x86_64-unknown-linux-gnu.tar.gz", bin = "gutenberg" }
+  { range = ">0.0.5, <0.4.3", tarball = "%s-v%s-x86_64-unknown-linux-gnu.tar.gz", bin = "gutenberg" }
+]
+
+zola = [
+  { range = ">=0.4.3", tarball = "%s-v%s-x86_64-unknown-linux-gnu.tar.gz", bin = "zola" }
 ]


### PR DESCRIPTION
Add zola as a replacement for gutenberg for versions equal or above 0.4.3

See https://github.com/Keats/gutenberg/issues/377 for the discussion about the new name. The repo hasn't been moved yet as I want to minimize disruption with netlify if possible.
