### PR TITLE
Remove go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 sudo: false
 
 go:
-  - 1.8
   - 1.9
 
 install: make deps


### PR DESCRIPTION
Fix travis builds.  1.8 is failing, and newer versions can be used by merging https://github.com/netlify/binrc/pull/24