### PR TITLE
include mdBook alias

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -32,9 +32,10 @@ const (
 // aliases is a map of known project aliases
 // to make finding project more easy.
 var aliases = map[string]string{
-	"hugo": "gohugoio/hugo",
+	"hugo":      "gohugoio/hugo",
 	"gutenberg": "keats/gutenberg",
 	"zola":      "getzola/zola",
+	"mdbook":    "rust-lang/mdbook",
 }
 
 type template struct {
@@ -115,7 +116,6 @@ func (c *Cache) newProject(name, versionString string) (*Project, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid version %s", versionString)
 	}
-
 	var t *template
 	projectTemplates, ok := c.templates[nwo[1]]
 	if ok {

--- a/templates/templates.toml
+++ b/templates/templates.toml
@@ -14,3 +14,7 @@ gutenberg = [
 zola = [
   { range = ">=0.5.0", tarball = "%s-v%s-x86_64-unknown-linux-gnu.tar.gz", bin = "zola" }
 ]
+
+mdbook = [
+  { range = ">=0.2.0", tarball = "%s-v%s-x86_64-unknown-linux-gnu.tar.gz", bin = "mdbook" }
+]


### PR DESCRIPTION
**- Summary**

I'd like to include mdBook in the netlify/build-image, however the binary format used in the github release assets do not conform to the default pattern. This PR includes an alias for the this project.

**- Test plan**
I have successfully run `make deps`, `make build`, `make lint`, and `make test` with these changes

```sh
go test ./...
?       github.com/netlify/binrc        [no test files]
?       github.com/netlify/binrc/cache  [no test files]
?       github.com/netlify/binrc/cmd    [no test files]
?       github.com/netlify/binrc/statik [no test files]
```

I have also successfully executed `binrc install mdbook 0.4.6`

**- Description for the changelog**

Add mdBook Alias

**- A picture of a cute animal (not mandatory but encouraged)**

Here is a baby Pudu!

![Pudu-Baby-Haechan-with-Dad-Mario-JEP_8990](https://user-images.githubusercontent.com/6232026/104683072-cb9eff00-56bb-11eb-8465-d6c59a6dfcf5.jpg)
